### PR TITLE
Remove old kernel poll

### DIFF
--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -110,11 +110,17 @@ const KernelUsage = (props: {
             'kernel'
           >
         ) => {
-          const kernelId = args.newValue?.id;
-          if (kernelId) {
-            setKernelId(kernelId);
+          const oldKernelId = args.oldValue?.id;
+          if (oldKernelId) {
+            const poll = kernelPools.get(oldKernelId);
+            poll?.poll.dispose();
+            kernelPools.delete(oldKernelId);
+          }
+          const newKernelId = args.newValue?.id;
+          if (newKernelId) {
+            setKernelId(newKernelId);
             const path = panel?.sessionContext.session?.model.path;
-            doPoll(kernelId as string, path as string);
+            doPoll(newKernelId as string, path as string);
           }
         }
       );


### PR DESCRIPTION
Fixes https://github.com/Quansight/jupyterlab-kernel-usage/issues/16

Remove old kernel poll. Especially needed when the user restart the kernel.